### PR TITLE
added fq option

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ Options:
   -q, --query <'f1:vl1 AND f2:vl2'>
           Solr Query param 'q' for filtering which documents are retrieved See: https://lucene.apache.org/solr/guide/6_6/the-standard-query-parser.html
 
+  -f, --fq <'f1:vl1 AND f2:vl2'>
+          Solr Filter Query param 'fq' for filtering which documents are retrieved See: https://solr.apache.org/guide/solr/latest/query-guide/common-query-parameters.html#fq-filter-query-parameter
+
   -o, --order <f1:asc,f2:desc,...>
           Solr core fields names for sorting documents for retrieval
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -60,26 +60,30 @@ pub(crate) struct Backup {
     #[arg(short, long, display_order = 40, value_name = "'f1:vl1 AND f2:vl2'")]
     pub query: Option<String>,
 
+    /// Solr Filter Query param 'fq' for filtering which documents are retrieved
+    #[arg(short = 'f', long, display_order = 41, value_name = "'f1:vl1 AND f2:vl2'")]
+    pub fq: Option<String>,
+
     /// Solr core fields names for sorting documents for retrieval
     #[arg(
         short,
         long,
-        display_order = 41,
+        display_order = 42,
         value_name = "f1:asc,f2:desc,...",
         value_delimiter = ','
     )]
     pub order: Vec<SortField>,
 
     /// Skip this quantity of documents in the Solr Query
-    #[arg(short = 'k', long, display_order = 42, value_parser = parse_quantity, default_value_t = 0, value_name = "quantity")]
+    #[arg(short = 'k', long, display_order = 43, value_parser = parse_quantity, default_value_t = 0, value_name = "quantity")]
     pub skip: u64,
 
     /// Maximum quantity of documents for retrieving from the core (like 100M)
-    #[arg(short, long, display_order = 43, value_parser = parse_quantity, value_name = "quantity")]
+    #[arg(short, long, display_order = 44, value_parser = parse_quantity, value_name = "quantity")]
     pub limit: Option<u64>,
 
     /// Names of core fields retrieved in each document [default: all but _*]
-    #[arg(short, long, display_order = 44, value_name = "field1,field2,...")]
+    #[arg(short, long, display_order = 45, value_name = "field1,field2,...")]
     pub select: Vec<String>,
 
     /// Slice the queries by using the variables {begin} and {end} for iterating in `--query`

--- a/src/steps.rs
+++ b/src/steps.rs
@@ -327,6 +327,8 @@ impl Backup {
         let qparam = self.query.as_deref().unwrap_or("*:*");
         let qfixed = self.replace_vars(qparam, raw);
         let filter = solr_query(&qfixed);
+        let fqparam = self.fq.as_deref().unwrap_or("*:*");
+        let fqparam = solr_query(&fqparam);
 
         let sort: String = if self.order.is_empty() {
             EMPTY_STRING
@@ -340,6 +342,7 @@ impl Backup {
             self.options.core.clone(),
             "/select?wt=json&indent=off&omitHeader=true".to_string(),
             format!("&q={}", filter),
+            format!("&fq={}", fqparam),
             sort,
             self.transfer.get_param("&"),
             selected.to_string(),


### PR DESCRIPTION
Added
```
  -f, --fq <'f1:vl1 AND f2:vl2'>
          Solr Filter Query param 'fq' for filtering which documents are retrieved
```

to restrict the superset of documents that can be returned, without influencing score.
See https://solr.apache.org/guide/solr/latest/query-guide/common-query-parameters.html#fq-filter-query-parameter